### PR TITLE
Fix link command not working without cross save

### DIFF
--- a/Commands/Utility.cs
+++ b/Commands/Utility.cs
@@ -26,26 +26,17 @@ namespace Levante.Commands
 
             await DeferAsync(true);
 
-            var memId = DataConfig.GetValidDestinyMembership(BungieTag, (Guardian.Platform) ArgPlatform,
-                out var memType);
+            var memId = DataConfig.GetValidDestinyMembership(BungieTag, (Guardian.Platform) ArgPlatform, out var memType);
 
             if (memId == null && memType == null)
             {
-                await Context.Interaction.ModifyOriginalResponseAsync(message =>
-                {
-                    message.Content =
-                        "Something went wrong. Is your Bungie Tag correct?";
-                });
+                await Context.Interaction.ModifyOriginalResponseAsync(message => { message.Content = "Something went wrong. Is your Bungie Tag correct?"; });
                 return;
             }
 
             if (!DataConfig.IsPublicAccount(BungieTag, int.Parse(memType)))
             {
-                await Context.Interaction.ModifyOriginalResponseAsync(message =>
-                {
-                    message.Content =
-                        "Your account privacy is not set to public. I cannot access your information otherwise.";
-                });
+                await Context.Interaction.ModifyOriginalResponseAsync(message => { message.Content = "Your account privacy is not set to public. I cannot access your information otherwise."; });
                 return;
             }
 
@@ -53,38 +44,9 @@ namespace Levante.Commands
 
             await Context.Interaction.ModifyOriginalResponseAsync(message =>
             {
-                message.Content = $"Linked {Context.User.Mention} to {BungieTag} on Platform {GetMembershipType(int.Parse(memType))}.\nIf the platform is incorrect, please `/unlink` and then use `/link {BungieTag} <platform>`.";
+                message.Content = $"Linked {Context.User.Mention} to {BungieTag} on Platform {(Guardian.Platform)int.Parse(memType)}.\nIf the platform is incorrect, please `/unlink` and then use `/link {BungieTag} <platform>`.";
             });
         }
-
-        private static string GetMembershipType(int MembershipType)
-        {
-            return MembershipType switch
-            {
-                1 => "Xbox",
-                2 => "PSN",
-                3 => "Steam",
-                4 => "Blizzard",
-                5 => "Stadia",
-                _ => "None"
-            };
-        }
-
-        [SlashCommand("rank", "Display a Destiny 2 leaderboard of choice.")]
-        public async Task Rank(
-            [Summary("leaderboard", "Specific leaderboard to display.")]
-            [Choice("Season Pass Level", 0)]
-            [Choice("Longest XP Logging Session", 1)]
-            [Choice("Most Logged XP Per Hour", 2)]
-            [Choice("Total XP Logging Time", 3)]
-            [Choice("Equipped Power Level", 4)]
-            int ArgLeaderboard,
-            [Summary("season", "Season of the specific leaderboard. Defaults to the current season.")]
-            [Choice("Season of the Lost", 15)]
-            [Choice("Season of the Risen", 16)]
-            int Season = 16)
-        {
-            var LeaderboardType = (Leaderboard) ArgLeaderboard;
 
         [Group("notify", "Be notified when a specific rotation is active.")]
         public class Notify : InteractionModuleBase<SocketInteractionContext>

--- a/Commands/Utility.cs
+++ b/Commands/Utility.cs
@@ -24,24 +24,67 @@ namespace Levante.Commands
                 return;
             }
 
-            string memId = DataConfig.GetValidDestinyMembership(BungieTag, (Guardian.Platform)ArgPlatform, out string memType);
+            await DeferAsync(true);
+
+            var memId = DataConfig.GetValidDestinyMembership(BungieTag, (Guardian.Platform) ArgPlatform,
+                out var memType);
 
             if (memId == null && memType == null)
             {
-                await RespondAsync($"Something went wrong. Is your Bungie Tag correct?", ephemeral: true);
+                await Context.Interaction.ModifyOriginalResponseAsync(message =>
+                {
+                    message.Content =
+                        "Something went wrong. Is your Bungie Tag correct?";
+                });
                 return;
             }
 
-            if (!DataConfig.IsPublicAccount(BungieTag))
+            if (!DataConfig.IsPublicAccount(BungieTag, int.Parse(memType)))
             {
-                await RespondAsync($"Your account privacy is not set to public. I cannot access your information otherwise.", ephemeral: true);
+                await Context.Interaction.ModifyOriginalResponseAsync(message =>
+                {
+                    message.Content =
+                        "Your account privacy is not set to public. I cannot access your information otherwise.";
+                });
                 return;
             }
 
             DataConfig.AddUserToConfig(Context.User.Id, memId, memType, BungieTag);
-            await RespondAsync($"Linked {Context.User.Mention} to {BungieTag}.", ephemeral: true);
+
+            await Context.Interaction.ModifyOriginalResponseAsync(message =>
+            {
+                message.Content = $"Linked {Context.User.Mention} to {BungieTag} on Platform {GetMembershipType(int.Parse(memType))}.\nIf the platform is incorrect, please `/unlink` and then use `/link {BungieTag} <platform>`.";
+            });
         }
 
+        private static string GetMembershipType(int MembershipType)
+        {
+            return MembershipType switch
+            {
+                1 => "Xbox",
+                2 => "PSN",
+                3 => "Steam",
+                4 => "Blizzard",
+                5 => "Stadia",
+                _ => "None"
+            };
+        }
+
+        [SlashCommand("rank", "Display a Destiny 2 leaderboard of choice.")]
+        public async Task Rank(
+            [Summary("leaderboard", "Specific leaderboard to display.")]
+            [Choice("Season Pass Level", 0)]
+            [Choice("Longest XP Logging Session", 1)]
+            [Choice("Most Logged XP Per Hour", 2)]
+            [Choice("Total XP Logging Time", 3)]
+            [Choice("Equipped Power Level", 4)]
+            int ArgLeaderboard,
+            [Summary("season", "Season of the specific leaderboard. Defaults to the current season.")]
+            [Choice("Season of the Lost", 15)]
+            [Choice("Season of the Risen", 16)]
+            int Season = 16)
+        {
+            var LeaderboardType = (Leaderboard) ArgLeaderboard;
 
         [Group("notify", "Be notified when a specific rotation is active.")]
         public class Notify : InteractionModuleBase<SocketInteractionContext>


### PR DESCRIPTION
Assume user doesn't have cross save enabled and doesn't specify a platform, get the last played profile and search for that one instead.

If it's incorrect then users should just RTFM and specify the platform themselves :) (but we're nice so we tell them that it may be wrong & how to fix it)