### PR TITLE
fix: emblem.report requiring API keys

### DIFF
--- a/Configs/BotConfig.cs
+++ b/Configs/BotConfig.cs
@@ -50,6 +50,9 @@ namespace Levante.Configs
         [JsonProperty("BungieClientSecret")]
         public static string BungieClientSecret { get; set; } = "[YOUR CLIENT SECRET HERE]";
 
+        [JsonProperty("EmblemReportApiKey")]
+        public static string EmblemReportApiKey { get; set; } = "[YOUR API KEY HERE]";
+
         [JsonProperty("Version")]
         public static string Version { get; set; } = "1.0.0";
 

--- a/Util/EmblemReport.cs
+++ b/Util/EmblemReport.cs
@@ -26,6 +26,8 @@ namespace Levante.Util
                 collectibles = new List<long> { collectibleHash }
             };
             using var client = new HttpClient();
+            client.DefaultRequestHeaders.UserAgent.ParseAdd($"Mozilla/5.0 (compatible; {BotConfig.AppName}/1.0)");
+            client.DefaultRequestHeaders.Add("X-API-KEY", BotConfig.EmblemReportApiKey);
             var postContent = new StringContent(JsonConvert.SerializeObject(collectiblesBody), Encoding.UTF8, "application/json");
 
             var response = client.PostAsync("https://emblem.report/api/getRarestEmblems", postContent).Result;


### PR DESCRIPTION
add: user agent to prevent cloudflare blocking